### PR TITLE
added client_multithread_communication

### DIFF
--- a/src/instrumental.c
+++ b/src/instrumental.c
@@ -222,7 +222,6 @@ void *send_music_to_server(void *arg){
   }
 
   system("/bin/stty cooked");  // 後始末
-
 }
 
 // ｓで指定した場所からデータを受け取って標準出力に出す関数

--- a/src/mypthread.c
+++ b/src/mypthread.c
@@ -1,7 +1,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include "../include/die.h"
-#include "../include/pthread.h"
+#include "../include/mypthread.h"
 
 #define N 1024
 

--- a/src/true_main.c
+++ b/src/true_main.c
@@ -62,8 +62,8 @@ int main(int argc, char **argv) {
 		int ret_send, ret_receive;
 
 		// send_music_from_client とrecv_music_by_clientをpthreadで並列に
-		ret_send = pthread_create(&thread_send, NULL, send_music_to_server, (void*)*s);
-		ret_receive = pthread_create(&thread_receive, NULL, recv_music_from_server, (void*)*s);
+		ret_send = pthread_create(&thread_send, NULL, send_music_to_server, (void*)&s);
+		ret_receive = pthread_create(&thread_receive, NULL, recv_music_from_server, (void*)&s);
 
 		if (ret_send != 0) die("pthread_create:send");
 		if (ret_receive != 0) die("pthread_create:receive");

--- a/src/true_main.c
+++ b/src/true_main.c
@@ -39,12 +39,12 @@ int main(int argc, char **argv) {
 		number_of_client = atoi(argv[3]);
 		ss = (int*)calloc(number_of_client, sizeof(int));
     if (ss == NULL) die("calloc");
-		server(port, number_of_client, )
+		server(port, number_of_client, ss);
 	}
 	else { // client
 		char *address = argv[1];
 		int port = atoi(argv[2]);
-		client(address, port, *s);
+		client(address, port, &s);
 	}
 
 	/* ここで接続完了 */
@@ -58,7 +58,26 @@ int main(int argc, char **argv) {
 	}
 
 	else {
+		pthread_t thread_send, thread_receive;
+		int ret_send, ret_receive;
+
 		// send_music_from_client とrecv_music_by_clientをpthreadで並列に
+		ret_send = pthread_create(&thread_send, NULL, send_music_to_server, (void*)*s);
+		ret_receive = pthread_create(&thread_receive, NULL, recv_music_from_server, (void*)*s);
+
+		if (ret_send != 0) die("pthread_create:send");
+		if (ret_receive != 0) die("pthread_create:receive");
+
+		fprintf(stderr, "succeeded to create threads\n");
+
+		// プログラムが終わる時
+		ret_send = pthread_join(thread_send, NULL);
+		ret_receive = pthread_join(thread_receive, NULL);
+
+		if (ret_send != 0) die("pthread_join:send");
+		if (ret_receive != 0) die("pthread_join:receive");
+
+		fprintf(stderr, "client job done\n");
 	}
 				
 


### PR DESCRIPTION
# クライアント側のマルチスレッド処理
- send_music_to_serverとrecv_music_from_serverを並列に走らせる．つまり波形をサーバに送るのと，サーバから波形をもらうのを並行で行う．
- もらった波形の再生は`play`でやるので，あとでシェルスクリプトに書きます．