### PR TITLE
modified timespec error

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -8,4 +8,4 @@ if [ $# -ne 3 ]; then
 fi
 
 # ./bin/main 10.213.150.58 50000 | play -t raw -b 16 -c 1 -e s -r 44100 -
-./bin/main $1 $2 $3 | play -t raw -b 16 -c 1 -e s -r 44100 -
+./bin/main $1 $2 $3 


### PR DESCRIPTION
# timespecのバグを直した．
- numerical argument out of boundsというエラーが出た．この原因はtimespecのメンバ変数tv_nsecの引数の範囲．
- [0, 1e9 - 1]が範囲なので，掛け算の過程で1e9以上にならないように調整する．